### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,5 +20,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.6+'
+    implementation 'com.facebook.react:react-native:0.6+'
 }


### PR DESCRIPTION
Changed "compile" with "implementation" since "compile" is deprecated since Gradle 7.0